### PR TITLE
fix: font-family to correct arrows

### DIFF
--- a/src/components/TypoAndPastePanel.vue
+++ b/src/components/TypoAndPastePanel.vue
@@ -94,6 +94,7 @@ export default {
   padding-inline: 0;
   cursor: pointer;
   line-height: var(--button-height);
+  font-family: system-ui, sans-serif;
 }
 
 .tap-dropdown__item:hover {


### PR DESCRIPTION
Hi @philippoehrlein,

thank you for this great plugin. This is really a nice addition to my projects. 

I just noticed a minor font-family issue, see this screenshot:

<img width="301" alt="before" src="https://github.com/user-attachments/assets/bf3987a6-8de4-4a1b-8e93-bff5a3886368">


Somehow the default font-family set in Kirby is causing this. Kirby is using `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"` and I think this issue is caused by `"Apple Color Emoji"` and I assume this is only an issue on MacOS/iOS.

In this case, where just simple glyphs are shown, I think it is just enough to use `system-ui, sans-serif` as a font-family. Browser-Support is pretty good, see https://caniuse.com/font-family-system-ui

Here is a screenshot using `system-ui, sans-serif`:
<img width="302" alt="after" src="https://github.com/user-attachments/assets/130f2bd2-ccd0-4d10-a82c-3249ac314611">

Let me know what you think. Have a nice weekend.